### PR TITLE
Fix hang when soft-reset arrives during $F= SD streaming

### DIFF
--- a/fs_stream.c
+++ b/fs_stream.c
@@ -795,7 +795,15 @@ FLASHMEM static status_code_t cmd_unlink (sys_state_t state, char *args)
 
 FLASHMEM static void onReset (void)
 {
-    if(hal.stream.type == StreamType_File && active_stream.type != StreamType_Null) {
+    // Tighten the guard: clean up if EITHER a file is open OR we hijacked the
+    // stream. The previous guard required hal.stream.type == StreamType_File,
+    // which fails transiently during tool-change suspend_read, on_stream_changed
+    // callbacks, and other paths that temporarily swap the stream type. When
+    // reset arrives during those windows the file handle leaks, hal.stream.read
+    // stays redirected at the file reader, and post-reset host traffic is
+    // misrouted — observed as grblHAL hangs + ioSender access violations on
+    // subsequent commands.
+    if(file.handle != NULL || active_stream.type != StreamType_Null) {
         if(file.line_number) {
             char buf[70];
             sprintf(buf, "Reset during streaming of file at line: " UINT32FMT, file.line_number);


### PR DESCRIPTION
## Summary

The cleanup branch in `onReset()` required `hal.stream.type == StreamType_File`, which transiently becomes false during tool-change `suspend_read` and `on_stream_changed` callbacks. A soft-reset arriving in that window leaks the file handle and the stream redirection.

Symptom: grblHAL hangs and ioSender access-violates on the next command; only a Teensy power-cycle recovers it.

## Fix

Tighten the guard to fire when **either** `file.handle` is open **or** `active_stream.type` is non-Null. `stream_end_job()` is already idempotent in both branches of the call path, so the broader condition can't double-clean.

## Test plan

- [x] Reproduce on master: stream a macro via `$F=/start_job.macro`, send `^X` during an M0 hold inside the streamed file → grblHAL stops responding, sender access-violates on next command.
- [x] With patch applied: same sequence → clean job termination, status report resumes, next g-code accepted.

---

Found while debugging an interactive SD-streamed tool-change workflow on grblHAL/iMXRT1062 (Teensy 4.1, BOARD_T41U5XBB).
