### PR TITLE
Add DEFAULT_MACRO_ATC_OPTIONS build-time default for $675

### DIFF
--- a/macros.c
+++ b/macros.c
@@ -281,7 +281,10 @@ FLASHMEM static void atc_path_fix (char *path)
 
 FLASHMEM static void macro_settings_restore (void)
 {
-    settings.macro_atc_flags.value = 0;
+#ifndef DEFAULT_MACRO_ATC_OPTIONS
+#define DEFAULT_MACRO_ATC_OPTIONS  0
+#endif
+    settings.macro_atc_flags.value = DEFAULT_MACRO_ATC_OPTIONS;
 }
 
 FLASHMEM static atc_status_t atc_get_state (void)


### PR DESCRIPTION
## Summary

The `$675` (Macro ATC options) setting is currently restored to `0` hardcoded on first boot or `$RST=$`. A build-time `#define DEFAULT_MACRO_ATC_OPTIONS <n>` lets drivers ship firmware where the setting defaults to something else — useful when senders want to detect ATC capability via the `ATC=0`/`ATC=1` token in `$I` rather than the generic `TC,` fallback.

## Why this change is safe

Follows the same `#ifndef DEFAULT_xxx` pattern used throughout `config.h` for other settings:

```c
#ifndef DEFAULT_MACRO_ATC_OPTIONS
#define DEFAULT_MACRO_ATC_OPTIONS 0
#endif
```

Default value unchanged when the override is absent. Single-line change to the settings-restore path.

## Test plan

- [x] Build with `-DDEFAULT_MACRO_ATC_OPTIONS=2`: fresh `$RST=$` → `$675` reads `2`.
- [x] Build without the override: `$675` reads `0` (unchanged behavior).
